### PR TITLE
Support GHC 8.6 through 8.10

### DIFF
--- a/splint.cabal
+++ b/splint.cabal
@@ -1,3 +1,5 @@
+cabal-version: 2.2
+
 name: splint
 version: 1.0.0.1
 
@@ -9,7 +11,6 @@ description:
   to ignore the "Use @concatMap@" suggestion.
 
 build-type: Simple
-cabal-version: >= 1.10
 category: Development
 extra-source-files: README.markdown
 license-file: LICENSE.markdown
@@ -20,17 +21,38 @@ source-repository head
   location: https://github.com/tfausak/splint
   type: git
 
-library
-  build-depends:
-    base >= 4.14.0 && < 4.15
-    , ghc >= 8.10.1 && < 8.11
-    , hlint >= 3.0 && < 3.2
+common basics
   default-language: Haskell2010
-  exposed-modules: Splint
   ghc-options:
     -Weverything
+    -Wno-all-missed-specialisations
     -Wno-implicit-prelude
-    -Wno-missing-safe-haskell-mode
-    -Wno-prepositive-qualified-module
+    -Wno-missing-exported-signatures
+    -Wno-missing-import-lists
+    -Wno-safe
     -Wno-unsafe
+
+  if impl(ghc >= 8.8)
+    ghc-options:
+      -Wno-missing-deriving-strategies
+
+  if impl(ghc >= 8.10)
+    ghc-options:
+      -Wno-missing-safe-haskell-mode
+      -Wno-prepositive-qualified-module
+
+library
+  import: basics
+
+  build-depends:
+    base >= 4.12.0 && < 4.15
+    , ghc >= 8.6.1 && < 8.11
+    , hlint >= 3.0 && < 3.2
+  exposed-modules: Splint
   hs-source-dirs: src/lib
+  other-modules: Splint.Parser
+
+  if impl(ghc == 8.10.*)
+    other-modules: Splint.Parser.Native
+  else
+    other-modules: Splint.Parser.Fallback

--- a/src/lib/Splint/Parser.hs
+++ b/src/lib/Splint/Parser.hs
@@ -1,0 +1,33 @@
+{-# LANGUAGE CPP #-}
+
+-- | Starting with HLint 3, it's possible to re-use the parsed module that GHC
+-- produces to avoid re-parsing the module. Unfortunately this is only possible
+-- when the GHC version matches the version that HLint expects. Otherwise we
+-- have to let HLint re-parse the module to produce it's expected AST.
+--
+-- This module is responsible for picking that behavior. The so-called "native"
+-- behavior is the one where GHC's parse module is re-used. The "fallback"
+-- parser is the one that re-parses the module.
+--
+-- Doing this requires a build-time decision, which means using CPP. Therefore
+-- this module is kept as small as possible in order to make it easier to
+-- reason about.
+--
+-- It is expected that both the "native" and "fallback" parsers expose the
+-- exact same interface.
+--
+-- You could in theory always use the "fallback" parser, but that would mean
+-- doing a lot of unnecessary work by re-parsing modules. Parsing is typically
+-- fast and this is hard to quantify, so if you want to go that route you
+-- should consider using Ollie Charles's hlint-source-plugin instead.
+-- <https://github.com/ocharles/hlint-source-plugin>
+module Splint.Parser
+  ( parse
+  )
+where
+
+#if (__GLASGOW_HASKELL__ == 810)
+import Splint.Parser.Native (parse)
+#else
+import Splint.Parser.Fallback (parse)
+#endif

--- a/src/lib/Splint/Parser/Fallback.hs
+++ b/src/lib/Splint/Parser/Fallback.hs
@@ -1,0 +1,35 @@
+module Splint.Parser.Fallback
+  ( parse
+  )
+where
+
+import qualified Control.Exception as Exception
+import qualified GhcPlugins as GHC
+import qualified Language.Haskell.HLint as HLint
+
+parse
+  :: HLint.ParseFlags
+  -> GHC.ModSummary
+  -> GHC.HsParsedModule
+  -> GHC.Hsc HLint.ModuleEx
+parse parseFlags modSummary _ = GHC.liftIO $ do
+  let filePath = GHC.msHsFilePath modSummary
+  result <- HLint.parseModuleEx parseFlags filePath Nothing
+  case result of
+    Left parseError -> Exception.throwIO $ ParseError parseError
+    Right moduleEx -> pure moduleEx
+
+newtype ParseError = ParseError HLint.ParseError
+
+instance Exception.Exception ParseError
+
+instance Show ParseError where
+  show (ParseError parseError) = mconcat
+    [ "ParseError { parseErrorLocation = "
+    , show $ HLint.parseErrorLocation parseError
+    , ", parseErrorMessage = "
+    , show $ HLint.parseErrorMessage parseError
+    , ", parseErrorContents = "
+    , show $ HLint.parseErrorContents parseError
+    , " }"
+    ]

--- a/src/lib/Splint/Parser/Native.hs
+++ b/src/lib/Splint/Parser/Native.hs
@@ -1,0 +1,18 @@
+module Splint.Parser.Native
+  ( parse
+  )
+where
+
+import qualified GhcPlugins as GHC
+import qualified Language.Haskell.HLint as HLint
+
+parse
+  :: HLint.ParseFlags
+  -> GHC.ModSummary
+  -> GHC.HsParsedModule
+  -> GHC.Hsc HLint.ModuleEx
+parse _ _ hsParsedModule = do
+  let
+    apiAnns = GHC.hpm_annotations hsParsedModule
+    hsModule = GHC.hpm_module hsParsedModule
+  pure $ HLint.createModuleEx apiAnns hsModule


### PR DESCRIPTION
Fixes #2.

There's a big comment in `Splint.Parser` explaining how this works. TL;DR: Re-parse using HLint for everything except GHC 8.10. 