### PR TITLE
Fix bugs when loading settings

### DIFF
--- a/splint.cabal
+++ b/splint.cabal
@@ -46,8 +46,10 @@ library
 
   build-depends:
     base >= 4.12.0 && < 4.15
+    , containers >= 0.6.0 && < 0.7
     , ghc >= 8.6.1 && < 8.11
     , hlint >= 3.0 && < 3.2
+    , stm >= 2.5.0 && < 2.6
   exposed-modules: Splint
   hs-source-dirs: src/lib
   other-modules: Splint.Parser


### PR DESCRIPTION
While testing Splint on some larger projects, I noticed I could reliably get a crash if I ran GHC with `-j`. Eventually I tracked the problem down to the call to `argsSettings`. This made me discover two bugs:

- Multiple threads could attempt to load the settings at the same time. If both threads started at about the same time, they would both see an empty settings value and then try to load the settings. The fix here was to introduce the `RemoteData` type with an explicit `Loading` constructor. If any other threads are currently loading the settings, they won't get fetched again. 

- Each file can set its own command-line options using `{-# OPTIONS_GHC -fplugin-opt=Splint:whatever #-}`. Since there was only one settings value, every file was forced to use the same settings. The fix here was to make a `Map` of settings, keyed on the options. 

This PR fixes the crash, prevents two threads from loading the same settings at the same time, and allows files to use different settings. 